### PR TITLE
malnin.nikita/F0

### DIFF
--- a/malanin.nikita/F0/IOFunction.cpp
+++ b/malanin.nikita/F0/IOFunction.cpp
@@ -1,0 +1,95 @@
+#include "IOFunctions.hpp"
+#include <fstream>
+#include <iostream>
+#include <algorithm>
+#include <functional>
+#include "workspace.hpp"
+
+const std::string& getName(std::pair< const std::string&, const malanin::Graph& > pair)
+{
+  return pair.first;
+}
+
+bool compareNames(const std::string& rhs, const std::string& lhs)
+{
+  return lhs == rhs;
+}
+
+bool nameIsNotUnique(const std::string& name, const malanin::Workspace& workspace)
+{
+  std::vector< std::string > names;
+  malanin::getGraphsNames(workspace, names);
+  {
+    using namespace std::placeholders;
+    bool nameAlreadyExists = std::any_of(
+      std::begin(names),
+      std::end(names),
+      std::bind(compareNames, _1, name)
+    );
+    return nameAlreadyExists;
+  }
+}
+
+void malanin::getGraphsNames(const malanin::Workspace& workspace, std::vector< std::string >& accumulator)
+{
+  std::transform(workspace.graphs.cbegin(), workspace.graphs.cend(), std::back_inserter(accumulator), getName);
+}
+
+void insertGraph(const malanin::Graph& graph, malanin::Workspace& workspace)
+{
+  const std::string& name = graph.name;
+  if (nameIsNotUnique(name, workspace))
+  {
+    throw std::logic_error("[ERROR](insertion): graph, named \"" + name + "\" already exists");
+  }
+  workspace.graphs.insert({name, graph});
+}
+
+void malanin::initWorkspace(int argc, char* argv[], malanin::Workspace& workspace)
+{
+  if (argc == 1)
+  {
+    return;
+  }
+  readGraph(argv[1], workspace.current);
+  insertGraph(workspace.current, workspace);
+  if (argc == 2)
+  {
+    return;
+  }
+  for (int i = 2; i < argc; i++)
+  {
+    Graph temp;
+    readGraph(argv[i], temp);
+    try
+    {
+      insertGraph(temp, workspace);
+    }
+    catch (const std::runtime_error& e)
+    {
+      std::cerr << e.what() << '\n';
+    }
+  }
+}
+
+void malanin::readGraph(const std::string& filename, malanin::Graph& container)
+{
+  std::ifstream in(filename);
+  if(!in)
+  {
+    throw std::runtime_error("[ERROR](input): error while opening file " + filename);
+  }
+  std::string name = "";
+  std::getline(in, name);
+
+  in >> container;
+  container.name = name;
+  container.filename = filename;
+
+  in.close();
+}
+
+std::ostream& malanin::sendMessage(std::ostream& out, const std::string& message)
+{
+  return out << message << '\n';
+}

--- a/malanin.nikita/F0/IOFunction.cpp
+++ b/malanin.nikita/F0/IOFunction.cpp
@@ -5,17 +5,20 @@
 #include <functional>
 #include "workspace.hpp"
 
-const std::string& getName(std::pair< const std::string&, const malanin::Graph& > pair)
+const std::string& getName(std::pair< const std::string&, 
+const malanin::Graph& > pair)
 {
   return pair.first;
 }
 
-bool compareNames(const std::string& rhs, const std::string& lhs)
+bool compareNames(const std::string& rhs, 
+const std::string& lhs)
 {
   return lhs == rhs;
 }
 
-bool nameIsNotUnique(const std::string& name, const malanin::Workspace& workspace)
+bool nameIsNotUnique(const std::string& name, 
+const malanin::Workspace& workspace)
 {
   std::vector< std::string > names;
   malanin::getGraphsNames(workspace, names);
@@ -30,22 +33,28 @@ bool nameIsNotUnique(const std::string& name, const malanin::Workspace& workspac
   }
 }
 
-void malanin::getGraphsNames(const malanin::Workspace& workspace, std::vector< std::string >& accumulator)
+void malanin::getGraphsNames(const malanin::Workspace& workspace, 
+std::vector< std::string >& accumulator)
 {
-  std::transform(workspace.graphs.cbegin(), workspace.graphs.cend(), std::back_inserter(accumulator), getName);
+  std::transform(workspace.graphs.cbegin(), 
+workspace.graphs.cend(), 
+std::back_inserter(accumulator), getName);
 }
 
-void insertGraph(const malanin::Graph& graph, malanin::Workspace& workspace)
+void insertGraph(const malanin::Graph& graph, 
+malanin::Workspace& workspace)
 {
   const std::string& name = graph.name;
   if (nameIsNotUnique(name, workspace))
   {
-    throw std::logic_error("[ERROR](insertion): graph, named \"" + name + "\" already exists");
+    throw std::logic_error("[ERROR](insertion): graph, named \"" + 
+name + "\" already exists");
   }
   workspace.graphs.insert({name, graph});
 }
 
-void malanin::initWorkspace(int argc, char* argv[], malanin::Workspace& workspace)
+void malanin::initWorkspace(int argc, char* argv[], 
+malanin::Workspace& workspace)
 {
   if (argc == 1)
   {
@@ -72,12 +81,14 @@ void malanin::initWorkspace(int argc, char* argv[], malanin::Workspace& workspac
   }
 }
 
-void malanin::readGraph(const std::string& filename, malanin::Graph& container)
+void malanin::readGraph(const std::string& filename, 
+malanin::Graph& container)
 {
   std::ifstream in(filename);
   if(!in)
   {
-    throw std::runtime_error("[ERROR](input): error while opening file " + filename);
+    throw std::runtime_error("[ERROR](input): error while\n"
+"opening file " + filename);
   }
   std::string name = "";
   std::getline(in, name);
@@ -89,7 +100,8 @@ void malanin::readGraph(const std::string& filename, malanin::Graph& container)
   in.close();
 }
 
-std::ostream& malanin::sendMessage(std::ostream& out, const std::string& message)
+std::ostream& malanin::sendMessage(std::ostream& out, 
+const std::string& message)
 {
   return out << message << '\n';
 }

--- a/malanin.nikita/F0/IOFunction.cpp
+++ b/malanin.nikita/F0/IOFunction.cpp
@@ -1,4 +1,4 @@
-#include "IOFunctions.hpp"
+#include "IOFunction.hpp"
 #include <fstream>
 #include <iostream>
 #include <algorithm>

--- a/malanin.nikita/F0/IOFunction.cpp
+++ b/malanin.nikita/F0/IOFunction.cpp
@@ -5,19 +5,19 @@
 #include <functional>
 #include "workspace.hpp"
 
-const std::string& getName(std::pair< const std::string&, 
+const std::string& getName(std::pair< const std::string&,
 const malanin::Graph& > pair)
 {
   return pair.first;
 }
 
-bool compareNames(const std::string& rhs, 
+bool compareNames(const std::string& rhs,
 const std::string& lhs)
 {
   return lhs == rhs;
 }
 
-bool nameIsNotUnique(const std::string& name, 
+bool nameIsNotUnique(const std::string& name,
 const malanin::Workspace& workspace)
 {
   std::vector< std::string > names;
@@ -33,27 +33,27 @@ const malanin::Workspace& workspace)
   }
 }
 
-void malanin::getGraphsNames(const malanin::Workspace& workspace, 
+void malanin::getGraphsNames(const malanin::Workspace& workspace,
 std::vector< std::string >& accumulator)
 {
-  std::transform(workspace.graphs.cbegin(), 
-workspace.graphs.cend(), 
+  std::transform(workspace.graphs.cbegin(),
+workspace.graphs.cend(),
 std::back_inserter(accumulator), getName);
 }
 
-void insertGraph(const malanin::Graph& graph, 
+void insertGraph(const malanin::Graph& graph,
 malanin::Workspace& workspace)
 {
   const std::string& name = graph.name;
   if (nameIsNotUnique(name, workspace))
   {
-    throw std::logic_error("[ERROR](insertion): graph, named \"" + 
+    throw std::logic_error("[ERROR](insertion): graph, named \"" +
 name + "\" already exists");
   }
   workspace.graphs.insert({name, graph});
 }
 
-void malanin::initWorkspace(int argc, char* argv[], 
+void malanin::initWorkspace(int argc, char* argv[],
 malanin::Workspace& workspace)
 {
   if (argc == 1)
@@ -81,7 +81,7 @@ malanin::Workspace& workspace)
   }
 }
 
-void malanin::readGraph(const std::string& filename, 
+void malanin::readGraph(const std::string& filename,
 malanin::Graph& container)
 {
   std::ifstream in(filename);
@@ -100,7 +100,7 @@ malanin::Graph& container)
   in.close();
 }
 
-std::ostream& malanin::sendMessage(std::ostream& out, 
+std::ostream& malanin::sendMessage(std::ostream& out,
 const std::string& message)
 {
   return out << message << '\n';

--- a/malanin.nikita/F0/IOFunction.hpp
+++ b/malanin.nikita/F0/IOFunction.hpp
@@ -1,0 +1,15 @@
+#ifndef IO_FUNCTIONS_HPP
+#define IO_FUNCTIONS_HPP
+
+#include "workspace.hpp"
+#include <vector>
+
+namespace malanin
+{
+  void getGraphsNames(const Workspace&, std::vector< std::string >&);
+  void initWorkspace(int argc, char* argv[], malanin::Workspace& workspace);
+  void readGraph(const std::string& filename, Graph& container);
+  std::ostream& sendMessage(std::ostream&, const std::string&);
+}
+
+#endif

--- a/malanin.nikita/F0/commands.cpp
+++ b/malanin.nikita/F0/commands.cpp
@@ -1,12 +1,12 @@
 #include "commands.hpp"
+#include "scopeguard.hpp"
+#include "IOFunctions.hpp"
 #include <iterator>
 #include <algorithm>
 #include <iostream>
 #include <limits>
 #include <fstream>
 #include <sstream>
-#include <scopeguard.hpp>
-#include "IOFunctions.hpp"
 
 std::ostream& malanin::commands::node(std::ostream& out, std::istream& in, malanin::Workspace& workspace)
 {

--- a/malanin.nikita/F0/commands.cpp
+++ b/malanin.nikita/F0/commands.cpp
@@ -1,6 +1,6 @@
 #include "commands.hpp"
 #include "scopeguard.hpp"
-#include "IOFunctions.hpp"
+#include "IOFunction.hpp"
 #include <iterator>
 #include <algorithm>
 #include <iostream>

--- a/malanin.nikita/F0/commands.cpp
+++ b/malanin.nikita/F0/commands.cpp
@@ -1,0 +1,280 @@
+#include "commands.hpp"
+#include <iterator>
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <fstream>
+#include <sstream>
+#include <scopeguard.hpp>
+#include "IOFunctions.hpp"
+
+std::ostream& malanin::commands::node(std::ostream& out, std::istream& in, malanin::Workspace& workspace)
+{
+  std::string action = "";
+  int node = -1;
+  in >> action >> node;
+  if (node < 0)
+  {
+    throw std::invalid_argument("[ERROR]: nodes can't be negative");
+  }
+  if (action == "add")
+  {
+    workspace.current.addNode(node);
+  }
+  else if (action == "rm")
+  {
+    workspace.current.rmNode(node);
+  }
+  else
+  {
+    throw std::invalid_argument("command node don't have such parameters");
+  }
+  return out;
+}
+
+std::ostream& malanin::commands::edge(std::ostream& out, std::istream& in, malanin::Workspace& workspace)
+{
+  std::string action = "";
+  int lnode = -1, rnode = -1;
+  in >> action >> lnode >> rnode;
+  if (action == "add")
+  {
+    size_t weight = 1;
+    in >> weight;
+    workspace.current.addEdge(lnode, rnode, weight);
+  }
+  else if (action == "rm")
+  {
+    workspace.current.rmEdge(lnode, rnode);
+  }
+  else
+  {
+    throw std::invalid_argument("command node don't have such parameters");
+  }
+  return out;
+}
+
+void updateGraph(malanin::Workspace& workspace, const malanin::Graph& graph)
+{
+  workspace.graphs.erase(graph.name);
+  workspace.graphs.insert({graph.name, graph});
+}
+
+void makeCastling(std::ostream& out, std::string nameOfNew, malanin::Workspace& workspace)
+{
+  updateGraph(workspace, workspace.current);
+  try
+  {
+    malanin::Graph newCurrent = workspace.graphs.at(nameOfNew);
+    workspace.current = newCurrent;
+  }
+  catch (const std::out_of_range& e)
+  {
+    malanin::sendMessage(out, "[ERROR]: graph with name \"" + nameOfNew + "\" doesn't exist\n");
+  }
+}
+
+void createGraphFromFile(std::istream& in, std::ostream& out, malanin::Workspace& workspace)
+{
+  std::string filename;
+  in >> filename;
+  malanin::Graph temp;
+  malanin::readGraph(filename, temp);
+  updateGraph(workspace, temp);
+  makeCastling(out, temp.name, workspace);
+  malanin::sendMessage(out, "[INFO] graph \"" + temp.name + "\" initialised succesfully");
+}
+
+void readGraphFromInput(std::istream& in, malanin::Graph& container)
+{
+  in.clear();
+  std::string input;
+  std::getline(in >> std::ws, input, '\n');
+  std::stringstream ss(input);
+  ss >> container;
+}
+
+void createGraphFrominput(std::istream& in, std::ostream& out, const std::string& name, malanin::Workspace& workspace)
+{
+  malanin::Graph temp;
+  temp.name = name;
+  out << "(" << name << "): ";
+
+  readGraphFromInput(in, temp);
+
+  updateGraph(workspace, temp);
+  makeCastling(out, name, workspace);
+  malanin::sendMessage(out, "[INFO] graph \"" + temp.name + "\" initialised succesfully\n");
+}
+
+void closeGraphWithoutSaving(std::istream& in, std::ostream& out, malanin::Workspace& workspace)
+{
+  std::string arg = "";
+  in >> arg;
+  workspace.graphs.erase(arg);
+  if (workspace.current.name == arg)
+  {
+    malanin::Graph substitution = workspace.graphs.begin()->second;
+    workspace.current = substitution;
+  }
+  malanin::sendMessage(out, "[INFO] graph \"" + arg + "\" was deleted");
+}
+
+std::ostream& malanin::commands::graph(std::ostream& out, std::istream& in, malanin::Workspace& workspace)
+{
+  std::string arg = "";
+  in >> arg;
+  if (arg == "add")
+  {
+    in >> arg;
+    if (arg == "-f")
+    {
+      createGraphFromFile(in, out, workspace);
+    }
+    else
+    {
+      createGraphFrominput(in, out, arg, workspace);
+    }
+  }
+  else if (arg == "close")
+  {
+    closeGraphWithoutSaving(in, out, workspace);
+  }
+  return out;
+}
+
+void printPath(std::ostream& out, const malanin::Graph::Path& path)
+{
+  out << "Path is: ";
+  std::copy(
+    path.path.begin(),
+    path.path.end(),
+    std::ostream_iterator< int >(out, " ")
+  );
+  out << '\n' << "Path length is: " << path.lenght << '\n';
+}
+
+std::ostream& malanin::commands::path(std::ostream& out, std::istream& in, const malanin::Workspace& workspace)
+{
+  // примет словом: all, any, count, exists
+  std::string arg;
+  int begin, end;
+  in >> arg >> begin >> end;
+  if (arg == "all")
+  {
+    workspace.current.printAllPaths(begin, end, out);
+  }
+  else if (arg == "any")
+  {
+    workspace.current.printAnyPath(begin, end, out);
+  }
+  else if (arg == "count")
+  {
+    size_t count = workspace.current.countPaths(begin, end);
+    out << "amount of paths: " << count << '\n';
+  }
+  else if (arg == "exists")
+  {
+    bool doExists = workspace.current.pathExists(begin, end);
+    std::string verdict = doExists? "exists" : "doesn't exist";
+    out << "path between nodes \"" << begin << "\" and \"" << end << "\" " << verdict << '\n';
+  }
+  else
+  {
+    throw std::invalid_argument("[ERROR]: path command takes only `all`, `any`, `exists` or `count` arguments, but \"" + arg + "\" given");
+  }
+
+  return out;
+}
+
+std::ostream& malanin::commands::list(std::ostream& out, std::istream&, const malanin::Workspace& workspace)
+{
+  std::vector< std::string > names;
+  malanin::getGraphsNames(workspace, names);
+  std::copy(
+    names.begin(),
+    names.end(),
+    std::ostream_iterator< const std::string& >(out, "\n")
+  );
+  return out;
+}
+
+std::ostream& malanin::commands::jump(std::ostream& out, std::istream& in, malanin::Workspace& workspace)
+{
+  std::string name = "";
+  std::getline(in >> std::ws, name);
+  updateGraph(workspace, workspace.current);
+  makeCastling(out, name, workspace);
+  return out;
+}
+
+std::ostream& malanin::commands::print(std::ostream& out, std::istream& in, const malanin::Workspace& workspace)
+{
+  std::string arg = "";
+  in >> arg;
+  if (arg == "nodes")
+  {
+    workspace.current.printNodes(out);
+  }
+  else if (arg == "edges")
+  {
+    workspace.current.printAllEdges(out);
+  }
+  else
+  {
+    throw std::invalid_argument("[ERROR]: commant takes only \"nodes\" and \"edges\" as parameters, while \"" + arg + "\" passed");
+  };
+  return out;
+}
+
+std::ostream& malanin::commands::save(std::ostream& out, std::istream& in, const malanin::Workspace& workspace)
+{
+  std::string arg = "";
+  in >> arg;
+  if (arg == "-r")
+  {
+    std::string filename = workspace.current.filename;
+    std::ofstream output(filename);
+    output << workspace.current.name << '\n';
+    workspace.current.printAllEdges(output);
+  }
+  else
+  {
+    std::ofstream output(arg);
+    output << workspace.current.name << '\n';
+    workspace.current.printAllEdges(output);
+  }
+  return sendMessage(out, "[INFO] graph \"" + workspace.current.name + "\" saved succesfully");
+}
+
+std::ostream& malanin::commands::help(std::ostream& out, std::istream&, const malanin::Workspace&)
+{
+  out << "help - prints listing of all commands with some clarifications\n" << '\n';
+  // out << "navigate < a > < b > - searches for the shortest path between nodes < a > and < b >. ";
+  // out << "Note: < a > < b > are positive integers\n\n";
+  out << "path < what > < a > < b > - a and b are 2 nodes, actions depend on 'what' argument. ";
+  out << "'all' prints all possible paths between nodes. 'any' prints first found path between nodes. ";
+  out << "'count' prints amount of paths between nodes. 'exists' prints if path between nodes exists\n\n";
+  out << "graph add < graphname > - lets user to create a new graph using standart input. ";
+  out << "write down edges in a-b:w format, where a and b are nodes and w is weight\n\n";
+  out << "graph add -f < filename > - reads a graph from file. note that file contains name of the graph too\n\n";
+  out << "print < what > - prints informations about graph. Take \"nodes\" or \"edges\" as arugents. ";
+  out << "If \"nodes\" passed, then prints the list of all nodes of focused graph. ";
+  out << "Else if \"edges\" was given, prints edges in format a-b:w, ";
+  out << "where a and b are nodes and w is weight of edge\n\n";
+  out << "list - prints list of all graphs in workspace\n\n";
+  out << "jump < graphname > - swithes focus to the graph named \"graphname\"\n\n";
+  out << "node add < number > - adds new node with name < number > to the focused graph\n\n";
+  out << "node rm < number > - removes node named < number > from focused graph\n\n";
+  out << "edge add < a > < b > < weight > - add an edge between nodes < a > and < b > with specified < weight >\n\n";
+  out << "edge rm < a, b > - removes edge between nodes < a > and < b >\n\n";
+  out << "save < filepath > - saves focused graph to file in < filepath >. If file doesn't exists it will be created\n\n";
+  out << "save -r - if file was read from file, it will be saved int this exact file\n\n";
+  out << "quit - close all graphs without saving\n";
+  return out;
+}
+std::ostream& malanin::commands::quit(std::ostream& out, std::istream&, malanin::Workspace& workspace)
+{
+  workspace.isActive = false;
+  return out;
+}

--- a/malanin.nikita/F0/commands.hpp
+++ b/malanin.nikita/F0/commands.hpp
@@ -1,0 +1,24 @@
+#ifndef COMMANDS_HPP
+#define COMMANDS_HPP
+
+#include "workspace.hpp"
+#include <functional>
+
+namespace malanin
+{
+  namespace commands
+  {
+    std::ostream& node(std::ostream&, std::istream&, Workspace&);
+    std::ostream& edge(std::ostream&, std::istream&, Workspace&);
+    std::ostream& graph(std::ostream&, std::istream&, Workspace&);
+    std::ostream& path(std::ostream&, std::istream&, const Workspace&);
+    std::ostream& list(std::ostream&, std::istream&, const Workspace&);
+    std::ostream& jump(std::ostream&, std::istream&, Workspace&);
+    std::ostream& print(std::ostream&, std::istream&, const Workspace&);
+    std::ostream& save(std::ostream&, std::istream&, const Workspace&);
+    std::ostream& help(std::ostream&, std::istream&, const Workspace&);
+    std::ostream& quit(std::ostream&, std::istream&, Workspace&);
+  }
+}
+
+#endif

--- a/malanin.nikita/F0/delimiters.cpp
+++ b/malanin.nikita/F0/delimiters.cpp
@@ -1,0 +1,49 @@
+#include "delimiters.hpp"
+
+std::istream& malanin::operator>>(std::istream& is, malanin::DelimiterIO&& exp)
+{
+  std::istream::sentry guard(is);
+  if (!guard)
+  {
+    return is;
+  }
+  char c = 0;
+  is >> c;
+  if (c != exp.expected)
+  {
+    is.setstate(std::ios::failbit);
+  }
+  return is;
+}
+
+std::istream& malanin::operator>>(std::istream& is, malanin::LabelIO&& value)
+{
+  std::istream::sentry sentry(is);
+  if (!sentry)
+  {
+    return is;
+  }
+  std::string data = "";
+  is >> data;
+  bool cmp = data != value.exp;
+  if (is and cmp)
+  {
+    is.setstate(std::ios::failbit);
+  }
+  return is;
+}
+
+std::istream& malanin::operator>>(std::istream& is, malanin::KeyIO&& value)
+{
+  std::istream::sentry sentry(is);
+  if (!sentry)
+  {
+    return is;
+  }
+  is >> value.ref;
+  if (value.ref != "key1" and value.ref != "key2" and value.ref != "key3")
+  {
+    is.setstate(std::ios::failbit);
+  }
+  return is;
+}

--- a/malanin.nikita/F0/delimiters.hpp
+++ b/malanin.nikita/F0/delimiters.hpp
@@ -1,0 +1,25 @@
+#ifndef DELIMITERS_HPP
+#define DELIMITERS_HPP
+
+#include <iostream>
+
+namespace malanin
+{
+  struct DelimiterIO
+  {
+    char expected;
+  };
+  struct LabelIO
+  {
+    std::string exp;
+  };
+  struct KeyIO
+  {
+    std::string& ref;
+  };
+  std::istream& operator>>(std::istream& is, DelimiterIO&&);
+  std::istream& operator>>(std::istream &in, LabelIO&&);
+  std::istream& operator>>(std::istream &in, KeyIO&&);
+}
+
+#endif

--- a/malanin.nikita/F0/graph.cpp
+++ b/malanin.nikita/F0/graph.cpp
@@ -12,7 +12,8 @@ void malanin::Graph::addNode(int name)
 {
   if (contains(name))
   {
-    throw std::invalid_argument("[ERROR](insertion): the node you want to add already exists");
+    throw std::invalid_argument("[ERROR](insertion): the node \n you want to "
+    "add already exists");
   }
   nodes_.insert({name, Node{name}});
 }

--- a/malanin.nikita/F0/graph.cpp
+++ b/malanin.nikita/F0/graph.cpp
@@ -12,7 +12,8 @@ void malanin::Graph::addNode(int name)
 {
   if (contains(name))
   {
-    throw std::invalid_argument("[ERROR](insertion): the node \n you want to "
+    throw std::invalid_argument("[ERROR](insertion): the node \n"
+"you want to "
     "add already exists");
   }
   nodes_.insert({name, Node{name}});
@@ -21,7 +22,8 @@ void malanin::Graph::addNode(int name)
 void malanin::Graph::rmNode(int name)
 {
   Node& node = nodes_.at(name);
-  for (auto iter(node.edges.begin()); iter != node.edges.end(); iter = node.edges.begin())
+  for (auto iter(node.edges.begin()); iter != node.edges.end();
+ iter = node.edges.begin())
   {
     int neighbourName = iter->dest;
     rmEdge(name, neighbourName);
@@ -34,11 +36,13 @@ void malanin::Graph::addEdge(int lnode, int rnode, size_t weight)
 {
   if (!contains(lnode))
   {
-    throw std::invalid_argument("[ERROR](connection): no node named " + std::to_string(lnode));
+    throw std::invalid_argument("[ERROR](connection): no node named "
+ + std::to_string(lnode));
   }
   if (!contains(rnode))
   {
-    throw std::invalid_argument("[ERROR](connection): no node named " + std::to_string(rnode));
+    throw std::invalid_argument("[ERROR](connection): no node named "
+ + std::to_string(rnode));
   }
 
   Node& leftNode = nodes_[lnode];
@@ -54,11 +58,13 @@ void malanin::Graph::rmEdge(int lnode, int rnode)
 {
   if (!contains(lnode))
   {
-    throw std::invalid_argument("[ERROR](connection): node named" + std::to_string(lnode) + " doesn't exist");
+    throw std::invalid_argument("[ERROR](connection): node named"
+ + std::to_string(lnode) + " doesn't exist");
   }
   if (!contains(rnode))
   {
-    throw std::invalid_argument("[ERROR](connection): node named" + std::to_string(rnode) + " doesn't exist");
+    throw std::invalid_argument("[ERROR](connection): node named"
+ + std::to_string(rnode) + " doesn't exist");
   }
 
   Node& leftNode = nodes_[lnode];
@@ -96,14 +102,16 @@ std::forward_list< int > dequeToForward(std::deque < int > dq)
   return std::forward_list< int >(dq.begin(), dq.end());
 }
 
-malanin::Graph::Path malanin::Graph::findAnyPath(int start, int finish) const
+malanin::Graph::Path malanin
+::Graph::findAnyPath(int start, int finish) const
 {
   DeepDetourer dd(*this);
   std::deque< int > path = dd.findAnyPath(start, finish);
   return Path{calcPathLength(path), dequeToForward(path)};
 }
 
-void malanin::Graph::printPath(const Path& path, std::ostream& out) const
+void malanin::Graph::printPath(const Path& path,
+ std::ostream& out) const
 {
   out << "Path nodes: ";
   for (auto iter(path.path.begin()); iter != path.path.end(); ++iter)
@@ -113,19 +121,21 @@ void malanin::Graph::printPath(const Path& path, std::ostream& out) const
   out << "\b; cumulative length: " << path.lenght << '\n';
 }
 
-void malanin::Graph::printAnyPath(int start, int finish, std::ostream& out) const
+void malanin::Graph::printAnyPath(int start,
+ int finish, std::ostream& out) const
 {
   DeepDetourer dd(*this);
   Path path = findAnyPath(start, finish);
   printPath(path, out);
 }
 
-std::forward_list< malanin::Graph::Path > malanin::Graph::findAllPaths(int start, int finish) const
+std::forward_list< malanin::Graph::Path >
+ malanin::Graph::findAllPaths(int start, int finish) const
 {
   DeepDetourer dd(*this);
   std::forward_list< Path > result;
-  // Великая путаница с типами - что же на самом деле считать путем
-  std::forward_list< std::deque< int > > paths = dd.findAllPaths(start, finish);
+  std::forward_list< std::deque< int > > paths = 
+dd.findAllPaths(start, finish);
   for (std::deque< int > rawPath : paths)
   {
     result.push_front(Path {calcPathLength(rawPath), dequeToForward(rawPath)});
@@ -142,7 +152,8 @@ void malanin::Graph::printAllPaths(int start, int finish, std::ostream& out) con
   }
 }
 
-std::ostream& malanin::Graph::printNodes(std::ostream& out) const
+std::ostream& malanin::Graph::
+printNodes(std::ostream& out) const
 {
   for (auto cIter(nodes_.cbegin()); cIter != nodes_.cend();)
   {
@@ -156,7 +167,8 @@ std::ostream& malanin::Graph::printNodes(std::ostream& out) const
   return out;
 }
 
-std::ostream& malanin::Graph::printAllEdges(std::ostream& out) const
+std::ostream& malanin::Graph::
+printAllEdges(std::ostream& out) const
 {
   for (auto iter(nodes_.begin()); iter != nodes_.end(); ++iter)
   {
@@ -165,11 +177,12 @@ std::ostream& malanin::Graph::printAllEdges(std::ostream& out) const
       out << iter->second.name << '-' << edge.dest << ':' << edge.weight << " ";
     }
   }
-  out << "\b\n"; // \b - это бэкспейс, потому что мне лень логически задавать когда надо не ставить пробел
+  out << "\b\n";
   return out;
 }
 
-std::ostream& malanin::Graph::Printer::printUniqueEdges(const Node& node, std::ostream& out)
+std::ostream& malanin::Graph::Printer::
+printUniqueEdges(const Node& node, std::ostream& out)
 {
   visitedNodes.insert(node.name);
   for (auto cIter(node.edges.cbegin()); cIter != node.edges.cend(); cIter++)
@@ -189,9 +202,11 @@ std::ostream& malanin::Graph::Printer::printUniqueEdges(const Node& node, std::o
   return out;
 }
 
-bool malanin::Graph::Printer::hasUniqueEdges(const Node& node) const
+bool malanin::Graph::Printer::
+hasUniqueEdges(const Node& node) const
 {
-  for (auto cIter(node.edges.cbegin()); cIter != node.edges.cend(); cIter++)
+  for (auto cIter(node.edges.cbegin());
+ cIter != node.edges.cend(); cIter++)
   {
     int destName = cIter->dest;
     bool isUnique = visitedNodes.count(destName) == 0;
@@ -203,7 +218,8 @@ bool malanin::Graph::Printer::hasUniqueEdges(const Node& node) const
   return false;
 }
 
-size_t malanin::Graph::Edge::HashFunction::operator()(const Edge& rhs) const
+size_t malanin::Graph::Edge::
+HashFunction::operator()(const Edge& rhs) const
 {
   size_t ptrHash = std::hash< int >()(rhs.dest);
   size_t weightHash = std::hash< size_t >()(rhs.weight) << 1;
@@ -215,7 +231,8 @@ bool malanin::Graph::Edge::operator==(const Edge& rhs) const
   return dest == rhs.dest && weight == rhs.weight;
 }
 
-std::istream& malanin::operator>>(std::istream& in, malanin::Graph& graph)
+std::istream& malanin::
+operator>>(std::istream& in, malanin::Graph& graph)
 {
   using del = malanin::DelimiterIO;
 
@@ -227,7 +244,8 @@ std::istream& malanin::operator>>(std::istream& in, malanin::Graph& graph)
     in >> lnode >> del{'-'} >> rnode >> del{':'} >> weight;
     if (in.fail() && !in.eof())
     {
-      std::cerr << "Warning: failed to read one of the nodes\n";
+      std::cerr << "Warning: failed to read\n"
+"one of the nodes\n";
       in.clear();
       in.ignore(std::numeric_limits< std::streamsize >::max(), ' ');
       continue;
@@ -250,22 +268,28 @@ bool malanin::Graph::contains(int nodeName) const
   return nodes_.count(nodeName) > 0;
 }
 
-malanin::Graph::DeepDetourer::DeepDetourer(const Graph& curGraph):
+malanin::Graph::
+DeepDetourer::
+DeepDetourer(const Graph& curGraph):
   graph_(curGraph)
 {}
 
-bool malanin::Graph::DeepDetourer::checkPathExistance(int begin, int end)
+bool malanin::Graph::DeepDetourer::
+checkPathExistance(int begin, int end)
 {
   return !findAnyPath(begin, end).empty();
 }
 
-size_t malanin::Graph::DeepDetourer::countPaths(int begin, int end)
+size_t malanin::Graph::DeepDetourer::
+countPaths(int begin, int end)
 {
-  std::forward_list< Path > paths = findAllPaths(begin, end);
+  std::forward_list< Path > paths =
+ findAllPaths(begin, end);
   return std::distance(paths.begin(), paths.end());
 }
 
-bool malanin::Graph::DeepDetourer::getPath(int begin, int end, Path& path)
+bool malanin::Graph::
+DeepDetourer::getPath(int begin, int end, Path& path)
 {
   if (begin == end)
   {
@@ -274,7 +298,8 @@ bool malanin::Graph::DeepDetourer::getPath(int begin, int end, Path& path)
   }
   passedNodes_.insert(begin);
   auto& edges = graph_.nodes_.at(begin).edges;
-  for (auto edgeIter(edges.begin()); edgeIter != edges.end(); ++ edgeIter)
+  for (auto edgeIter(edges.begin()); edgeIter !=
+ edges.end(); ++ edgeIter)
   {
     if (!passedNodes_.count(edgeIter->dest))
     {
@@ -288,14 +313,17 @@ bool malanin::Graph::DeepDetourer::getPath(int begin, int end, Path& path)
   return false;
 }
 
-malanin::Graph::DeepDetourer::Path malanin::Graph::DeepDetourer::findAnyPath(int begin, int end)
+malanin::Graph::DeepDetourer::Path malanin::
+Graph::DeepDetourer::
+findAnyPath(int begin, int end)
 {
   Path path;
   getPath(begin, end, path);
   return path;
 }
 
-bool malanin::Graph::DeepDetourer::doPathContainsNode(int node, const Path& path)
+bool malanin::Graph::DeepDetourer::
+doPathContainsNode(int node, const Path& path)
 {
   for (auto iter(path.begin()); iter != path.end(); ++iter)
   {
@@ -307,7 +335,9 @@ bool malanin::Graph::DeepDetourer::doPathContainsNode(int node, const Path& path
   return false;
 }
 
-void malanin::Graph::DeepDetourer::getAllPaths(int begin, int end, std::forward_list< Path >& paths, Path curPath)
+void malanin::Graph::DeepDetourer::getAllPaths(int begin,
+ int end, std::forward_list< Path >& paths,
+ Path curPath)
 {
   if (begin == end)
   {
@@ -327,7 +357,9 @@ void malanin::Graph::DeepDetourer::getAllPaths(int begin, int end, std::forward_
   passedNodes_.erase(begin);
 }
 
-std::forward_list< malanin::Graph::DeepDetourer::Path > malanin::Graph::DeepDetourer::findAllPaths(int begin, int end)
+std::forward_list< malanin::
+Graph::DeepDetourer::Path > malanin::Graph::
+DeepDetourer::findAllPaths(int begin, int end)
 {
   std::forward_list< Path > paths;
   getAllPaths(begin, end, paths, Path());

--- a/malanin.nikita/F0/graph.cpp
+++ b/malanin.nikita/F0/graph.cpp
@@ -1,0 +1,334 @@
+#include "graph.hpp"
+#include <delimiters.hpp>
+#include <algorithm>
+#include <utility>
+#include <vector>
+#include <limits>
+#include <sstream>
+#include <iterator>
+#include <algorithm>
+
+void malanin::Graph::addNode(int name)
+{
+  if (contains(name))
+  {
+    throw std::invalid_argument("[ERROR](insertion): the node you want to add already exists");
+  }
+  nodes_.insert({name, Node{name}});
+}
+
+void malanin::Graph::rmNode(int name)
+{
+  Node& node = nodes_.at(name);
+  for (auto iter(node.edges.begin()); iter != node.edges.end(); iter = node.edges.begin())
+  {
+    int neighbourName = iter->dest;
+    rmEdge(name, neighbourName);
+    rmEdge(neighbourName, name);
+  }
+  nodes_.erase(name);
+}
+
+void malanin::Graph::addEdge(int lnode, int rnode, size_t weight)
+{
+  if (!contains(lnode))
+  {
+    throw std::invalid_argument("[ERROR](connection): no node named " + std::to_string(lnode));
+  }
+  if (!contains(rnode))
+  {
+    throw std::invalid_argument("[ERROR](connection): no node named " + std::to_string(rnode));
+  }
+
+  Node& leftNode = nodes_[lnode];
+  Node& rightNode = nodes_[rnode];
+
+  Edge fromLeftToRight{rightNode.name, weight};
+
+  leftNode.edges.insert(fromLeftToRight);
+  rightNode.backLinks.insert({lnode, fromLeftToRight});
+}
+
+void malanin::Graph::rmEdge(int lnode, int rnode)
+{
+  if (!contains(lnode))
+  {
+    throw std::invalid_argument("[ERROR](connection): node named" + std::to_string(lnode) + " doesn't exist");
+  }
+  if (!contains(rnode))
+  {
+    throw std::invalid_argument("[ERROR](connection): node named" + std::to_string(rnode) + " doesn't exist");
+  }
+
+  Node& leftNode = nodes_[lnode];
+  Node& rightNode = nodes_[rnode];
+
+  leftNode.edges.erase(rightNode.backLinks[lnode]);
+  rightNode.backLinks.erase(lnode);
+}
+
+bool malanin::Graph::pathExists(int start, int finish) const
+{
+  DeepDetourer dd(*this);
+  return dd.checkPathExistance(start, finish);
+}
+
+size_t malanin::Graph::countPaths(int start, int finish) const
+{
+  DeepDetourer dd(*this);
+  return dd.countPaths(start, finish);
+}
+
+size_t malanin::Graph::calcPathLength(const std::deque< int >& path) const
+{
+  size_t length = 0;
+  for (auto iter(next(path.begin())); iter != path.end(); ++iter)
+  {
+    auto& backlinks = nodes_.at(*iter).backLinks;
+    length += backlinks.at(*std::prev(iter)).weight;
+  }
+  return length;
+}
+
+std::forward_list< int > dequeToForward(std::deque < int > dq)
+{
+  return std::forward_list< int >(dq.begin(), dq.end());
+}
+
+malanin::Graph::Path malanin::Graph::findAnyPath(int start, int finish) const
+{
+  DeepDetourer dd(*this);
+  std::deque< int > path = dd.findAnyPath(start, finish);
+  return Path{calcPathLength(path), dequeToForward(path)};
+}
+
+void malanin::Graph::printPath(const Path& path, std::ostream& out) const
+{
+  out << "Path nodes: ";
+  for (auto iter(path.path.begin()); iter != path.path.end(); ++iter)
+  {
+    out << *iter << ' ';
+  }
+  out << "\b; cumulative length: " << path.lenght << '\n';
+}
+
+void malanin::Graph::printAnyPath(int start, int finish, std::ostream& out) const
+{
+  DeepDetourer dd(*this);
+  Path path = findAnyPath(start, finish);
+  printPath(path, out);
+}
+
+std::forward_list< malanin::Graph::Path > malanin::Graph::findAllPaths(int start, int finish) const
+{
+  DeepDetourer dd(*this);
+  std::forward_list< Path > result;
+  // Великая путаница с типами - что же на самом деле считать путем
+  std::forward_list< std::deque< int > > paths = dd.findAllPaths(start, finish);
+  for (std::deque< int > rawPath : paths)
+  {
+    result.push_front(Path {calcPathLength(rawPath), dequeToForward(rawPath)});
+  }
+  return result;
+}
+
+void malanin::Graph::printAllPaths(int start, int finish, std::ostream& out) const
+{
+  std::forward_list< Path > paths = findAllPaths(start, finish);
+  for (Path path : paths)
+  {
+    printPath(path, out);
+  }
+}
+
+std::ostream& malanin::Graph::printNodes(std::ostream& out) const
+{
+  for (auto cIter(nodes_.cbegin()); cIter != nodes_.cend();)
+  {
+    out << cIter->first;
+    if (++cIter != nodes_.end())
+    {
+      out << ' ';
+    }
+  }
+  out << '\n';
+  return out;
+}
+
+std::ostream& malanin::Graph::printAllEdges(std::ostream& out) const
+{
+  for (auto iter(nodes_.begin()); iter != nodes_.end(); ++iter)
+  {
+    for (const Edge& edge : iter->second.edges)
+    {
+      out << iter->second.name << '-' << edge.dest << ':' << edge.weight << " ";
+    }
+  }
+  out << "\b\n"; // \b - это бэкспейс, потому что мне лень логически задавать когда надо не ставить пробел
+  return out;
+}
+
+std::ostream& malanin::Graph::Printer::printUniqueEdges(const Node& node, std::ostream& out)
+{
+  visitedNodes.insert(node.name);
+  for (auto cIter(node.edges.cbegin()); cIter != node.edges.cend(); cIter++)
+  {
+    int destinationName = cIter->dest;
+    size_t weight = cIter -> weight;
+    bool edgeIsUnique = visitedNodes.count(destinationName) == 0;
+    if (edgeIsUnique)
+    {
+      if (cIter != node.edges.begin())
+      {
+        out << ' ';
+      }
+      out << node.name << '-' << destinationName << ':' << weight;
+    }
+  }
+  return out;
+}
+
+bool malanin::Graph::Printer::hasUniqueEdges(const Node& node) const
+{
+  for (auto cIter(node.edges.cbegin()); cIter != node.edges.cend(); cIter++)
+  {
+    int destName = cIter->dest;
+    bool isUnique = visitedNodes.count(destName) == 0;
+    if (isUnique)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+size_t malanin::Graph::Edge::HashFunction::operator()(const Edge& rhs) const
+{
+  size_t ptrHash = std::hash< int >()(rhs.dest);
+  size_t weightHash = std::hash< size_t >()(rhs.weight) << 1;
+  return ptrHash ^ weightHash;
+}
+
+bool malanin::Graph::Edge::operator==(const Edge& rhs) const
+{
+  return dest == rhs.dest && weight == rhs.weight;
+}
+
+std::istream& malanin::operator>>(std::istream& in, malanin::Graph& graph)
+{
+  using del = malanin::DelimiterIO;
+
+  int lnode = -1, rnode = -1;
+  size_t weight;
+
+  while(!in.eof())
+  {
+    in >> lnode >> del{'-'} >> rnode >> del{':'} >> weight;
+    if (in.fail() && !in.eof())
+    {
+      std::cerr << "Warning: failed to read one of the nodes\n";
+      in.clear();
+      in.ignore(std::numeric_limits< std::streamsize >::max(), ' ');
+      continue;
+    }
+    if (!graph.contains(lnode))
+    {
+      graph.addNode(lnode);
+    }
+    if (!graph.contains(rnode))
+    {
+      graph.addNode(rnode);
+    }
+    graph.addEdge(lnode, rnode, weight);
+  }
+  return in;
+}
+
+bool malanin::Graph::contains(int nodeName) const
+{
+  return nodes_.count(nodeName) > 0;
+}
+
+malanin::Graph::DeepDetourer::DeepDetourer(const Graph& curGraph):
+  graph_(curGraph)
+{}
+
+bool malanin::Graph::DeepDetourer::checkPathExistance(int begin, int end)
+{
+  return !findAnyPath(begin, end).empty();
+}
+
+size_t malanin::Graph::DeepDetourer::countPaths(int begin, int end)
+{
+  std::forward_list< Path > paths = findAllPaths(begin, end);
+  return std::distance(paths.begin(), paths.end());
+}
+
+bool malanin::Graph::DeepDetourer::getPath(int begin, int end, Path& path)
+{
+  if (begin == end)
+  {
+    path.push_front(begin);
+    return true;
+  }
+  passedNodes_.insert(begin);
+  auto& edges = graph_.nodes_.at(begin).edges;
+  for (auto edgeIter(edges.begin()); edgeIter != edges.end(); ++ edgeIter)
+  {
+    if (!passedNodes_.count(edgeIter->dest))
+    {
+      if (getPath(edgeIter->dest, end, path))
+      {
+        path.push_front(begin);
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+malanin::Graph::DeepDetourer::Path malanin::Graph::DeepDetourer::findAnyPath(int begin, int end)
+{
+  Path path;
+  getPath(begin, end, path);
+  return path;
+}
+
+bool malanin::Graph::DeepDetourer::doPathContainsNode(int node, const Path& path)
+{
+  for (auto iter(path.begin()); iter != path.end(); ++iter)
+  {
+    if (*iter == node)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+void malanin::Graph::DeepDetourer::getAllPaths(int begin, int end, std::forward_list< Path >& paths, Path curPath)
+{
+  if (begin == end)
+  {
+    Path pathCopy = curPath;
+    pathCopy.push_back(end);
+    paths.push_front(pathCopy);
+  }
+  curPath.push_back(begin);
+  auto& edges = graph_.nodes_.at(begin).edges;
+  for (auto edgeIter(edges.begin()); edgeIter != edges.end(); ++ edgeIter)
+  {
+    if (!doPathContainsNode(edgeIter->dest, curPath))
+    {
+      getAllPaths(edgeIter->dest, end, paths, curPath);
+    }
+  }
+  passedNodes_.erase(begin);
+}
+
+std::forward_list< malanin::Graph::DeepDetourer::Path > malanin::Graph::DeepDetourer::findAllPaths(int begin, int end)
+{
+  std::forward_list< Path > paths;
+  getAllPaths(begin, end, paths, Path());
+  return paths;
+}

--- a/malanin.nikita/F0/graph.cpp
+++ b/malanin.nikita/F0/graph.cpp
@@ -86,10 +86,12 @@ size_t malanin::Graph::countPaths(int start, int finish) const
   return dd.countPaths(start, finish);
 }
 
-size_t malanin::Graph::calcPathLength(const std::deque< int >& path) const
+size_t malanin::Graph::calcPathLength(const std::
+deque< int >& path) const
 {
   size_t length = 0;
-  for (auto iter(next(path.begin())); iter != path.end(); ++iter)
+  for (auto iter(next(path.begin()));
+ iter != path.end(); ++iter)
   {
     auto& backlinks = nodes_.at(*iter).backLinks;
     length += backlinks.at(*std::prev(iter)).weight;
@@ -97,7 +99,8 @@ size_t malanin::Graph::calcPathLength(const std::deque< int >& path) const
   return length;
 }
 
-std::forward_list< int > dequeToForward(std::deque < int > dq)
+std::forward_list< int >
+ dequeToForward(std::deque < int > dq)
 {
   return std::forward_list< int >(dq.begin(), dq.end());
 }
@@ -134,7 +137,7 @@ std::forward_list< malanin::Graph::Path >
 {
   DeepDetourer dd(*this);
   std::forward_list< Path > result;
-  std::forward_list< std::deque< int > > paths = 
+  std::forward_list< std::deque< int > > paths =
 dd.findAllPaths(start, finish);
   for (std::deque< int > rawPath : paths)
   {

--- a/malanin.nikita/F0/graph.cpp
+++ b/malanin.nikita/F0/graph.cpp
@@ -1,5 +1,5 @@
 #include "graph.hpp"
-#include <delimiters.hpp>
+#include "delimiters.hpp"
 #include <algorithm>
 #include <utility>
 #include <vector>

--- a/malanin.nikita/F0/graph.hpp
+++ b/malanin.nikita/F0/graph.hpp
@@ -1,0 +1,107 @@
+#ifndef GRAPH_HPP
+#define GRAPH_HPP
+
+#include <unordered_set>
+#include <map>
+#include <unordered_map>
+#include <forward_list>
+#include <deque>
+#include <iostream>
+
+namespace malanin
+{
+  class Graph
+  {
+  private:
+    struct Node;
+    struct Edge;
+
+  public:
+    Graph() = default;
+
+    void addNode(int name);
+    void addEdge(int lnode, int rnode, size_t weight = 1);
+    void rmNode(int name);
+    void rmEdge(int lnode, int rnode);
+
+    struct Path;
+    Path navigate(int start, int finish) const;
+    bool pathExists(int start, int finish) const;
+    size_t countPaths(int start, int finish) const;
+    Path findAnyPath(int start, int finish) const;
+    void printAnyPath(int start, int finish, std::ostream&) const;
+    std::forward_list< Path > findAllPaths(int start, int finish) const;
+    void printAllPaths(int start, int finish, std::ostream&) const;
+
+    std::ostream& printNodes(std::ostream& = std::cout) const;
+    std::ostream& printAllEdges(std::ostream& = std::cout) const;
+    bool contains(int nodeName) const;
+
+    std::string name;
+    std::string filename;
+  private:
+    std::map< int, Node > nodes_;
+
+    struct Printer;
+    struct DeepDetourer;
+
+    size_t calcPathLength(const std::deque< int >& path) const;
+    void printPath(const Path&, std::ostream&) const;
+  };
+
+  struct Graph::Path
+  {
+    size_t lenght;
+    std::forward_list< int > path;
+  };
+
+  struct Graph::Printer
+  {
+    std::ostream& printUniqueEdges(const Node&, std::ostream&);
+    bool hasUniqueEdges(const Node&) const;
+    std::unordered_set< int > visitedNodes;
+  };
+
+  struct Graph::DeepDetourer
+  {
+    using Path = std::deque< int >;
+
+    DeepDetourer(const Graph&);
+
+    bool checkPathExistance(int begin, int end);
+    size_t countPaths(int begin, int end);
+    Path findAnyPath(int begin, int end);
+    std::forward_list< Path > findAllPaths(int begin, int end);
+
+    bool getPath(int begin, int end, Path& path);
+    void getAllPaths(int begin, int end, std::forward_list< Path >& paths, Path curPath);
+    bool doPathContainsNode(int node, const Path& path);
+
+    std::unordered_set< int > passedNodes_;
+    const Graph& graph_;
+  };
+
+  struct Graph::Edge
+  {
+    int dest;
+    size_t weight;
+    struct HashFunction;
+    bool operator==(const Edge&) const;
+  };
+
+  struct Graph::Edge::HashFunction
+  {
+    size_t operator()(const Edge& rhs) const;
+  };
+
+  struct Graph::Node
+  {
+    int name;
+    std::unordered_set< Edge, Edge::HashFunction > edges;
+    std::map< int, Edge > backLinks;
+  };
+  std::istream& operator>>(std::istream&, Graph&);
+
+}
+
+#endif

--- a/malanin.nikita/F0/main.cpp
+++ b/malanin.nikita/F0/main.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+#include <fstream>
+#include <functional>
+#include <limits>
+#include "workspace.hpp"
+#include "commands.hpp"
+#include "IOFunctions.hpp"
+
+#include <sstream>
+
+int main(int argc, char* argv[])
+{
+  using namespace malanin;
+
+  Graph initialGraph;
+  initialGraph.name = "untitled";
+  Workspace workspace{{}, initialGraph, true};
+  initWorkspace(argc, argv, workspace);
+
+  std::map< std::string, std::function< std::ostream&(std::ostream&, std::istream&, Workspace&) > > commands;
+  {
+    using namespace std::placeholders;
+    commands["node"] = malanin::commands::node;
+    commands["edge"] = malanin::commands::edge;
+    commands["graph"] = malanin::commands::graph;
+    commands["path"] = malanin::commands::path;
+    commands["list"] = malanin::commands::list;
+    commands["jump"] = malanin::commands::jump;
+    commands["print"] = malanin::commands::print;
+    commands["save"] = malanin::commands::save;
+    commands["help"] = malanin::commands::help;
+    commands["quit"] = malanin::commands::quit;
+  }
+
+  std::string command = "";
+  while(workspace.isActive && !std::cin.eof())
+  {
+    std::cout << "[" << workspace.current.name <<"]~> ";
+    command = "";
+    std::cin >> std::ws >> command;
+
+    if (command == "" && std::cin.eof())
+    {
+      commands.at("quit")(std::cout, std::cin, workspace) << '\n';
+      continue;
+    }
+    try
+    {
+      commands.at(command)(std::cout, std::cin, workspace);
+    }
+    catch (const std::invalid_argument& e)
+    {
+      sendMessage(std::cerr, e.what());
+      std::cin.ignore(std::numeric_limits< std::streamsize >::max(), '\n');
+    }
+    catch (const std::out_of_range& e)
+    {
+      sendMessage(std::cerr, "[ERROR] invalid command");
+      std::cin.ignore(std::numeric_limits< std::streamsize >::max(), '\n');
+    }
+    catch (const std::runtime_error& e)
+    {
+      sendMessage(std::cerr, e.what());
+      std::cin.ignore(std::numeric_limits< std::streamsize >::max(), '\n');
+    }
+  }
+
+  malanin::sendMessage(std::cout, "[EXIT] Goodbye!");
+  return 0;
+}

--- a/malanin.nikita/F0/main.cpp
+++ b/malanin.nikita/F0/main.cpp
@@ -4,7 +4,7 @@
 #include <limits>
 #include "workspace.hpp"
 #include "commands.hpp"
-#include "IOFunctions.hpp"
+#include "IOFunction.hpp"
 
 #include <sstream>
 

--- a/malanin.nikita/F0/scopeguard.cpp
+++ b/malanin.nikita/F0/scopeguard.cpp
@@ -1,0 +1,15 @@
+#include "scopeguard.hpp"
+
+malanin::iofmtguard::iofmtguard(std::basic_ios< char >& s):
+  s_(s),
+  fill_(s.fill()),
+  precision_(s.precision()),
+  fmt_(s.flags())
+{}
+
+malanin::iofmtguard::~iofmtguard()
+{
+  s_.fill(fill_);
+  s_.precision(precision_);
+  s_.flags(fmt_);
+}

--- a/malanin.nikita/F0/scopeguard.hpp
+++ b/malanin.nikita/F0/scopeguard.hpp
@@ -1,0 +1,21 @@
+#ifndef SCOPEGUARD_HPP
+#define SCOPEGUARD_HPP
+
+#include <iostream>
+
+namespace malanin
+{
+  class iofmtguard
+  {
+  public:
+    iofmtguard(std::basic_ios< char >& s);
+    ~iofmtguard();
+  private:
+    std::basic_ios< char >& s_;
+    char fill_;
+    std::streamsize precision_;
+    std::basic_ios< char >::fmtflags fmt_;
+  };
+}
+
+#endif

--- a/malanin.nikita/F0/workspace.hpp
+++ b/malanin.nikita/F0/workspace.hpp
@@ -1,0 +1,17 @@
+#ifndef WORKSPACE_HPP
+#define WORKSPACE_HPP
+
+#include "graph.hpp"
+#include <vector>
+
+namespace malanin
+{
+  struct Workspace
+  {
+    std::map< std::string, Graph > graphs;
+    Graph current;
+    bool isActive;
+  };
+}
+
+#endif


### PR DESCRIPTION
2.3.1. Алгоритм обхода в глубину для ориентированного графа

help - prints listing of all commands with some clarifications

navigate < a > < b > - searches for the shortest path between nodes < a > and < b >. Note: < a > < b > are positive integers

graph add < graphname > - lets user to create a new graph using standart input. It special opens input prompt, where user can write down all nodes with their weights in format a-b:w, where a and b are nodes and w is weight. After the graph is initialised, it will be focused

graph add -f < filename > - reads a graph from file. note that file contains name of the graph too

print < what > - prints informations about graph. Take "nodes" or "edges" as arugents. If "nodes" passed, then prints the list of all nodes of focused graph. Else if "edges" was given, prints edges in format a-b:w, where a and b are nodes and w is weight of edge

list - prints list of all graphs in workspace

jump < graphname > - swithes focus to the graph named "graphname"

node add < number > - adds new node with name < number > to the focused graph.

node rm < number > - removes node named < number > from focused graph

edge add < a > < b > < weight > - add an edge between nodes < a > and < b > with specified < weight >

edge rm < a, b > - removes edge between nodes < a > and < b >

save < filepath > - saves focused graph to file in < filepath >. If file doesn't exists it will be created

save -r - if file was read from file, it will be saved int this exact file

quit - close all graphs without saving